### PR TITLE
Replace deprecated function with the most recent one

### DIFF
--- a/imagecolor/ImageColorPlugin.php
+++ b/imagecolor/ImageColorPlugin.php
@@ -36,7 +36,7 @@ craft()->on('assets.onSaveFileContent', function(Event $event) {
     
     }
 	
-    public function hookAddTwigExtension()
+    public function addTwigExtension()
     {
         Craft::import('plugins.imagecolor.twigextensions.ImageColorTwigExtension');
         return new ImageColorTwigExtension();


### PR DESCRIPTION
Craft said "The “hook” prefix on the Craft\ImageColorPlugin::hookAddTwigExtension() method name has been deprecated. It should be renamed to addTwigExtension()."
